### PR TITLE
Add functionality to receive aqls from aqilles package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1619,6 +1619,14 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-loader": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -3806,8 +3814,7 @@
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-      "dev": true
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/AqlOrg/aql-monitor#readme",
   "dependencies": {
+    "axios": "^0.20.0",
     "d3": "^6.2.0",
     "express": "^4.17.1",
     "graphql": "^15.3.0",

--- a/server/controllers/traqlController.js
+++ b/server/controllers/traqlController.js
@@ -3,79 +3,44 @@ const db = require('../model.js');
 const traqlController = {};
 
 traqlController.addAqlsToTraql = (req, res, next) => {
-  // our server that lives for all time will be aql-monitor. aql-monitor is now home base more than just the dashboard
-  // way to test: set up aql-monitor to receive aqls, try sending hardcoded aql via postman
-  // way to test axios req is to console log it in traqlAudit in testState
-  let { traql, entryType } = req.body;
-  if(entryType === 'success') {
-    // send the traql entry to the Aqls database
+  let receivedTraqlEntries = req.body;
+  let queryString = '';
+  // create query string to send Aqls to the database
+  if(!receivedTraqlEntries.successAqls.length) {
     // create base of query string to send all values to db
-    let queryString = `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, user_token) values`;
-    // loop through aqls in mutation Id
-    for (let aql of traql.aqlsReceivedBack) {
-      // add one aql of data to query string
-      queryString = queryString.concat(`('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, '${aql.userToken}'),`);
-    }
-    // format the query to end with a semicolon, rather than a comma
-    queryString = queryString.slice(0, -1);
-    queryString = queryString + ';';
-    db.query(queryString, (err, response) => {
-      if (err) {
-        return next(err);
+    queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, user_token) values`;
+    for(let traql of receivedTraqlEntries.successAqls) {
+      // loop through aqls in mutation Id
+      for (let aql of traql.aqlsReceivedBack) {
+        // add one aql of data to query string
+        queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, '${aql.userToken}'),`;
       }
-
-
-      // somethings going on with sending back 200
-
-
-      console.log('i think things were added 1?');
-      return next();
-    });
-  } else if(entryType === 'error') {
-    for (let aql of traql.aqlsReceivedBack) {
-      // add the successful Aqls to the database
-      // TODO: update this else statement query to be similar to the loop above. create error query string base and then loop through aqls so error req only sends one long request to the database
-      const errorQueryString = `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, error, user_token) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`;
-      const errorQueryValues = [
-        aql.id,
-        aql.mutationSendTime,
-        aql.mutationReceived,
-        aql.subscriberReceived,
-        aql.roundtripTime,
-        aql.mutationId,
-        aql.resolver,
-        traql.expectedNumberOfAqls,
-        traql.aqlsReceivedBack.length,
-        true,
-        aql.userToken,
-      ];
-      db.query(errorQueryString, errorQueryValues, (err, response) => {
-        if (err) {
-          return next(err);
-        }
-        console.log('i think things were added 2a?')
-        return next();
-      });
-      // create error row for db with mutationID and traql stats
-      const traqlErrorQueryString = `insert into Aql (mutation_id, mutation_received_time, resolver, expected_subscribers, successful_subscribers, error, user_token) values ($1, $2, $3, $4, $5, $6, $7)`;
-      const traqlErrorValues = [
-        traql.mutationId,
-        traql.openedTime,
-        traql.resolver,
-        traql.expectedNumberOfAqls,
-        traql.aqlsReceivedBack.length,
-        true,
-        traql.userToken,
-      ];
-      db.query(traqlErrorQueryString, traqlErrorValues, (err, response) => {
-        if (err) {
-          return next(err);
-        }
-        console.log('i think things were added 2b?');
-        return next();
-      });
-    }        
+      // format the query to remove final comma
+      queryString = queryString.slice(0, -1);
+    }
   }
+  if(!receivedTraqlEntries.errorAqls.length) {
+    queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, error, user_token) values`;
+    for(let traql of receivedTraqlEntries.errorAqls) {
+      for (let aql of traql.aqlsReceivedBack) {
+        // add each aql to the query string
+        queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, 'true', '${aql.userToken}'),`;
+      }
+      // create error row for db with mutationID and traql stats
+      queryString += `insert into Aql (mutation_id, mutation_received_time, resolver, expected_subscribers, successful_subscribers, error, user_token) values ('${traql.mutationId}', '${traql.openedTime}', '${traql.resolver}', '${traql.expectedNumberOfAqls}', '${traql.aqlsReceivedBack.length}', 'true', '${traql.userToken}')`;
+    }
+    // format the query to remove final comma
+    queryString = queryString.slice(0, -1);
+  }
+  // add semicolon to end of query
+  queryString = queryString + ';';
+  db.query(queryString, (err, response) => {
+    if (err) {
+      return next(err);
+    }
+    console.log('Sucessfully added aqls to db');
+    return next();
+  });
   return next();
 };
 

--- a/server/controllers/traqlController.js
+++ b/server/controllers/traqlController.js
@@ -6,39 +6,41 @@ traqlController.addAqlsToTraql = (req, res, next) => {
   let receivedTraqlEntries = req.body;
   let queryString = '';
   // create query string to send Aqls to the database
-  if(!receivedTraqlEntries.successAqls.length) {
+  if(receivedTraqlEntries.successAqls.length) {
     // create base of query string to send all values to db
-    queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, user_token) values`;
+    queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, user_token) values `;
     for(let traql of receivedTraqlEntries.successAqls) {
       // loop through aqls in mutation Id
       for (let aql of traql.aqlsReceivedBack) {
         // add one aql of data to query string
-        queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, '${aql.userToken}'),`;
+        queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', '${traql.expectedNumberOfAqls}', '${traql.aqlsReceivedBack.length}', '${aql.userToken}'),`;
       }
-      // format the query to remove final comma
-      queryString = queryString.slice(0, -1);
     }
+    // format the query to remove final comma and add semicolon at end
+    queryString = queryString.slice(0, -1) + ';';
   }
-  if(!receivedTraqlEntries.errorAqls.length) {
-    queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, error, user_token) values`;
+  if(receivedTraqlEntries.errorAqls.length) {
     for(let traql of receivedTraqlEntries.errorAqls) {
-      for (let aql of traql.aqlsReceivedBack) {
-        // add each aql to the query string
-        queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, 'true', '${aql.userToken}'),`;
+      if(traql.aqlsReceivedBack.length) {
+        queryString += `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, error, user_token) values `;
+        for (let aql of traql.aqlsReceivedBack) {
+          // add each aql to the query string
+          queryString += `('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, 'true', '${aql.userToken}'),`;
+        }
+      // format the query to remove final comma and add semicolon at end
+      queryString = queryString.slice(0, -1) + ';';
       }
       // create error row for db with mutationID and traql stats
-      queryString += `insert into Aql (mutation_id, mutation_received_time, resolver, expected_subscribers, successful_subscribers, error, user_token) values ('${traql.mutationId}', '${traql.openedTime}', '${traql.resolver}', '${traql.expectedNumberOfAqls}', '${traql.aqlsReceivedBack.length}', 'true', '${traql.userToken}')`;
+      queryString += `insert into Aql (mutation_id, mutation_received_time, resolver, expected_subscribers, successful_subscribers, error, user_token) values ('${traql.mutationId}', '${traql.openedTime}', '${traql.resolver}', '${traql.expectedNumberOfAqls}', '${traql.aqlsReceivedBack.length}', 'true', '${traql.userToken}');`;
     }
-    // format the query to remove final comma
-    queryString = queryString.slice(0, -1);
   }
-  // add semicolon to end of query
-  queryString = queryString + ';';
+  console.log('query string');
+  console.log(queryString);
   db.query(queryString, (err, response) => {
     if (err) {
       return next(err);
     }
-    console.log('Sucessfully added aqls to db');
+    console.log('Data successfully added to db');
     return next();
   });
   return next();

--- a/server/controllers/traqlController.js
+++ b/server/controllers/traqlController.js
@@ -1,0 +1,82 @@
+const db = require('../model.js');
+
+const traqlController = {};
+
+traqlController.addAqlsToTraql = (req, res, next) => {
+  // our server that lives for all time will be aql-monitor. aql-monitor is now home base more than just the dashboard
+  // way to test: set up aql-monitor to receive aqls, try sending hardcoded aql via postman
+  // way to test axios req is to console log it in traqlAudit in testState
+  let { traql, entryType } = req.body;
+  if(entryType === 'success') {
+    // send the traql entry to the Aqls database
+    // create base of query string to send all values to db
+    let queryString = `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, user_token) values`;
+    // loop through aqls in mutation Id
+    for (let aql of traql.aqlsReceivedBack) {
+      // add one aql of data to query string
+      queryString = queryString.concat(`('${aql.id}', '${aql.mutationSendTime}', '${aql.mutationReceived}', '${aql.subscriberReceived}', '${aql.roundtripTime}', '${aql.mutationId}', '${aql.resolver}', ${traql.expectedNumberOfAqls}, ${traql.aqlsReceivedBack.length}, '${aql.userToken}'),`);
+    }
+    // format the query to end with a semicolon, rather than a comma
+    queryString = queryString.slice(0, -1);
+    queryString = queryString + ';';
+    db.query(queryString, (err, response) => {
+      if (err) {
+        return next(err);
+      }
+
+
+      // somethings going on with sending back 200
+
+
+      console.log('i think things were added 1?');
+      return next();
+    });
+  } else if(entryType === 'error') {
+    for (let aql of traql.aqlsReceivedBack) {
+      // add the successful Aqls to the database
+      // TODO: update this else statement query to be similar to the loop above. create error query string base and then loop through aqls so error req only sends one long request to the database
+      const errorQueryString = `insert into Aql (id, mutation_send_time, mutation_received_time, subscriber_received_time, latency, mutation_id, resolver, expected_subscribers, successful_subscribers, error, user_token) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`;
+      const errorQueryValues = [
+        aql.id,
+        aql.mutationSendTime,
+        aql.mutationReceived,
+        aql.subscriberReceived,
+        aql.roundtripTime,
+        aql.mutationId,
+        aql.resolver,
+        traql.expectedNumberOfAqls,
+        traql.aqlsReceivedBack.length,
+        true,
+        aql.userToken,
+      ];
+      db.query(errorQueryString, errorQueryValues, (err, response) => {
+        if (err) {
+          return next(err);
+        }
+        console.log('i think things were added 2a?')
+        return next();
+      });
+      // create error row for db with mutationID and traql stats
+      const traqlErrorQueryString = `insert into Aql (mutation_id, mutation_received_time, resolver, expected_subscribers, successful_subscribers, error, user_token) values ($1, $2, $3, $4, $5, $6, $7)`;
+      const traqlErrorValues = [
+        traql.mutationId,
+        traql.openedTime,
+        traql.resolver,
+        traql.expectedNumberOfAqls,
+        traql.aqlsReceivedBack.length,
+        true,
+        traql.userToken,
+      ];
+      db.query(traqlErrorQueryString, traqlErrorValues, (err, response) => {
+        if (err) {
+          return next(err);
+        }
+        console.log('i think things were added 2b?');
+        return next();
+      });
+    }        
+  }
+  return next();
+};
+
+module.exports = traqlController;

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const app = express();
 const PORT = 3000;
 
 const router = require('./router');
+const traqlRouter = require('./traqlRouter');
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -13,6 +14,7 @@ app.use(cors({ origin: ['http://localhost:8080', 'http://localhost:3000'] }));
 
 app.use(express.static('public'));
 
+app.use('/aqls', traqlRouter);
 app.use('/api', router);
 
 // ---------------------- GitHub OAuth Section ----------------------- //

--- a/server/traqlAudit.js
+++ b/server/traqlAudit.js
@@ -1,0 +1,14 @@
+// whole point is giving package a "gun" and traqlaudit will run when it gets aqls, stick them in gun, fire via axios to our server
+// to test, start server on test-state and play color game and see logs and stuff
+
+// developer expects that when someone plays, aql gets triggered, by the end, they have all aqls on their server
+// so we actually need to be sending aqls baql to the developer of fiesta color game. so to test-state. via res.locals and axios return
+
+// traql audit runs on traql, lives on developer's repo, catches back all aqls from developer's front end (fiesta color game)
+
+// they instead need to on their server in traqlAudit, send all of their aqls to an endpoint on our server
+
+
+// TODO: Instead of making these queries from here, we need to bundle up the Traql entry and send it to an endpoint that we create on the Aql Monitor server. This endpoint will be the same endpoint for all developers using Aqls. All Traql entries will be sent here. In Aql-monitor server.js, create a new endpoint that will be this endpoint. Then take a lot of this logic in traqlAudit.js and move it into the endpoint controller. This is to help it interface with the database. It's not safe to give them access to our DB. Instead of developer's server to access our DB, developer is going to send it to our server. TraqlAudit will audit itself, bundle up things and send them somewhere. What we are changing with the middleware is where they're going. So now that they're going to our server, that's why this functionality is going into our server. BOOM
+
+// probably want to do router and controller. when i get to /analytics/aqls, req is going to be from developer's servers, and I want to take body of req, pop it off, and add all of those aqls into our db, just like we are currently doing above. Basically cutting and pasting these functionalities to other servers and change these to axios requests. fetch vs axios: fetch uses browser api, is a browser function. we're in an express function, so there is no browser. thus need to use axios. will need to install axios.

--- a/server/traqlRouter.js
+++ b/server/traqlRouter.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const db = require('./model');
+const traqlRouter = express.Router();
+const traqlController = require('./controllers/traqlController');
+
+traqlRouter.post('/', traqlController.addAqlsToTraql, (req, res) => {
+  res.sendStatus(200);
+});
+
+module.exports = traqlRouter;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose

- Transfer database addition functionality from aqilles package to aql-monitor.

<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
## Approach
<!--- How does your change address the problem? -->

- Add functionality to receive aqls from aqilles package.
- One query of all received aqls is created for entry into the database.
- First, all success aqls are parameterized for entry into the database.
- Then, all error aqls and data are appented to the query.
- Finally, the entries are added to the database and a success status response is returned to the user.


